### PR TITLE
config.guest should be config.user

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var Client = function(config) {
 	var options = {
 		host : config.host || 'localhost',
 		port : config.port || 15672, 
-		auth : (config.guest || 'guest') + ':' + (config.password || 'guest'),
+		auth : (config.user || 'guest') + ':' + (config.password || 'guest'),
 		headers:{
         	"content-type" : "application/json"
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-rabbitmq-manager",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "RabbitMQ HTTP API client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
README specifies that when passing the config, `user` should be used to specify the username for RabbitMQ however currently `guest` is used. I have changed this to use user and not guest.